### PR TITLE
update dependabot behavior

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,13 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    ignore:
+      # ignore newer versions since GitHub Actions uses node 16.x
+      - dependency-name: "@types/node"
+        versions: [">=17.0.0"]


### PR DESCRIPTION
Switch to weekly updates and don't update @types/node higher than what GitHub Actions run with.